### PR TITLE
Redo extraction of charging values

### DIFF
--- a/run-preprint.sh
+++ b/run-preprint.sh
@@ -9,4 +9,5 @@ mkdir -p logs
 
 snakemake \
     --configfile=config/config-preprint.yml \
-    --profile cluster
+    --profile cluster \
+    --rerun-incomplete

--- a/run-test.sh
+++ b/run-test.sh
@@ -8,5 +8,5 @@
 mkdir -p results/logs
 
 snakemake \
-  --configfile=config/config.yml \
+  --configfile=config/config-test.yml \
   --profile cluster

--- a/workflow/scripts/get_charging_table.py
+++ b/workflow/scripts/get_charging_table.py
@@ -1,0 +1,39 @@
+#! /usr/bin/env python
+
+"""
+Generate table of read id, ref, value of charging tag
+"""
+
+import pysam
+import argparse
+import csv
+import gzip
+
+def extract_tag(bam_file, output_tsv, tag):
+
+    open_func = gzip.open if output_tsv.endswith(".gz") else open
+    mode = "wt" if output_tsv.endswith(".gz") else "w"
+
+    with (
+        pysam.AlignmentFile(bam_file, "rb") as bam,
+        open_func(output_tsv, mode) as tsvfile
+    ):
+        writer = csv.writer(tsvfile, delimiter="\t")
+        writer.writerow(["read_id", "tRNA", "charging_likelihood"])
+
+        for read in bam.fetch():
+            read_id = read.query_name
+            reference = read.reference_name if read.reference_name else "*"
+            tag_value = dict(read.tags).get(tag, None)
+
+            if tag_value and reference != "*":
+                writer.writerow([read_id, reference, tag_value])
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Extract a specified tag from a BAM file and write to TSV.")
+    parser.add_argument("bam_file", help="Input BAM file")
+    parser.add_argument("output_tsv", help="Output TSV file (can be .gz for compression)")
+    parser.add_argument("--tag", default="ML", help="BAM tag to extract (default: ML)")
+
+    args = parser.parse_args()
+    extract_tag(args.bam_file, args.output_tsv, args.tag)

--- a/workflow/scripts/get_charging_table.py
+++ b/workflow/scripts/get_charging_table.py
@@ -9,8 +9,6 @@ import argparse
 import csv
 import gzip
 
-import pdb
-
 
 def extract_tag(bam_file, output_tsv, tag):
 
@@ -29,6 +27,9 @@ def extract_tag(bam_file, output_tsv, tag):
             reference = read.reference_name if read.reference_name else "*"
             tag_array = dict(read.tags).get(tag, None)
 
+            # XXX: handle case where there are more than 1 tag value
+            # not clear why this is, but we skip for now as it's a small 
+            # number of reads affected
             if len(tag_array) > 1:
                 continue
 

--- a/workflow/scripts/get_charging_table.py
+++ b/workflow/scripts/get_charging_table.py
@@ -9,6 +9,9 @@ import argparse
 import csv
 import gzip
 
+import pdb
+
+
 def extract_tag(bam_file, output_tsv, tag):
 
     open_func = gzip.open if output_tsv.endswith(".gz") else open
@@ -16,7 +19,7 @@ def extract_tag(bam_file, output_tsv, tag):
 
     with (
         pysam.AlignmentFile(bam_file, "rb") as bam,
-        open_func(output_tsv, mode) as tsvfile
+        open_func(output_tsv, mode) as tsvfile,
     ):
         writer = csv.writer(tsvfile, delimiter="\t")
         writer.writerow(["read_id", "tRNA", "charging_likelihood"])
@@ -24,15 +27,25 @@ def extract_tag(bam_file, output_tsv, tag):
         for read in bam.fetch():
             read_id = read.query_name
             reference = read.reference_name if read.reference_name else "*"
-            tag_value = dict(read.tags).get(tag, None)
+            tag_array = dict(read.tags).get(tag, None)
+
+            if len(tag_array) > 1:
+                continue
+
+            tag_value = tag_array[0]
 
             if tag_value and reference != "*":
                 writer.writerow([read_id, reference, tag_value])
 
+
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Extract a specified tag from a BAM file and write to TSV.")
+    parser = argparse.ArgumentParser(
+        description="Extract a specified tag from a BAM file and write to TSV."
+    )
     parser.add_argument("bam_file", help="Input BAM file")
-    parser.add_argument("output_tsv", help="Output TSV file (can be .gz for compression)")
+    parser.add_argument(
+        "output_tsv", help="Output TSV file (can be .gz for compression)"
+    )
     parser.add_argument("--tag", default="ML", help="BAM tag to extract (default: ML)")
 
     args = parser.parse_args()


### PR DESCRIPTION
Closes #45 

Uncovered an issue wherein a small number of reads have >= 1 value for ML (charging tag). Not sure why that is, but for now we ditch them (it was < 10 reads for a large run).

Split `get_final_bam_and_charg_prob` into 2 rules:

1. transfer_bam_tags
2. get_cca_trna

Replace the awk / sed strategy of extracting chargin values with a python script.

